### PR TITLE
Update to client to allow the index parameter to be undefined

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,14 +17,14 @@ type Client struct {
 }
 
 // NewClient returns a new initialised elasticsearch client with the default dp-net/http client
-func NewClient(url string, signRequests bool, maxRetries int, indexes []string) *Client {
+func NewClient(url string, signRequests bool, maxRetries int, indexes ...string) *Client {
 	httpClient := dphttp.NewClient()
 	httpClient.SetMaxRetries(maxRetries)
-	return NewClientWithHTTPClient(url, signRequests, httpClient, indexes)
+	return NewClientWithHTTPClient(url, signRequests, httpClient, indexes...)
 }
 
 // NewClientWithHTTPClient returns a new initialised elasticsearch client with the provided HTTP client
-func NewClientWithHTTPClient(url string, signRequests bool, httpCli dphttp.Clienter, indexes []string) *Client {
+func NewClientWithHTTPClient(url string, signRequests bool, httpCli dphttp.Clienter, indexes ...string) *Client {
 	return &Client{
 		httpCli:      httpCli,
 		url:          url,

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -24,11 +24,9 @@ const (
 
 const testUrl = "http://some.url"
 
-var testIndex = []string{"one"}
+var testIndex = "one"
 
-var testNoClientIndex = []string{}
-
-var testTwoIndexes = []string{"one", "two"}
+var testTwoIndexes = "two"
 
 // Error definitions for testing
 var (
@@ -302,7 +300,7 @@ func TestNoClientIndex(t *testing.T) {
 			return doOkGreen(ctx, request)
 		}}
 
-		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli, testNoClientIndex)
+		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli)
 
 		// CheckState for test validation
 		checkState := health.NewCheckState(elasticsearch.ServiceName)
@@ -329,7 +327,7 @@ func TestTwoIndexesExist(t *testing.T) {
 			return doOkGreen(ctx, request)
 		}}
 
-		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli, testTwoIndexes)
+		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli, testIndex, testTwoIndexes)
 
 		// CheckState for test validation
 		checkState := health.NewCheckState(elasticsearch.ServiceName)
@@ -360,7 +358,7 @@ func TestOneOfTwoIndexesExist(t *testing.T) {
 			}
 			return doOkGreen(ctx, request)
 		}}
-		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli, testTwoIndexes)
+		cli := elasticsearch.NewClientWithHTTPClient(testUrl, true, httpCli, testIndex, testTwoIndexes)
 
 		// CheckState for test validation
 		checkState := health.NewCheckState(elasticsearch.ServiceName)


### PR DESCRIPTION
### What

Changed the index parameter in the client method to be a variable argument list rather than an array so that in the client the indexes can be undefined.

### How to review

Check that the tests pass, and also that the logic in the checkIndex and checker functions still makes sense with this change.

### Who can review

Anyone other than me