### PR TITLE
update go module to include v2

### DIFF
--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ONSdigital/dp-elasticsearch/elasticsearch"
+	"github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/elasticsearch/healthcheck_test.go
+++ b/elasticsearch/healthcheck_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ONSdigital/dp-elasticsearch/elasticsearch"
+	"github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	. "github.com/smartystreets/goconvey/convey"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ONSdigital/dp-elasticsearch
+module github.com/ONSdigital/dp-elasticsearch/v2
 
 go 1.15
 


### PR DESCRIPTION
### What

- Currently the module can't be imported so there is a need to include /v2 in the go module

### How to review

- Check that the module name is inline with the standard

### Who can review

Anyone but me
