### PR TITLE
Add search method for ES 7.10

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	NewBulkIndexer(context.Context) error
 	UpdateAliases(ctx context.Context, alias string, removeIndices, addIndices []string) error
 	MultiSearch(ctx context.Context, searches []Search) ([]byte, error)
+	Search(ctx context.Context, search Search) ([]byte, error)
 	CountIndices(ctx context.Context, indices []string) ([]byte, error)
 }
 

--- a/client/elasticsearch/v2/client.go
+++ b/client/elasticsearch/v2/client.go
@@ -242,3 +242,7 @@ func (cli *Client) BulkIndexClose(context.Context) error {
 func (cli *Client) MultiSearch(ctx context.Context, searches []client.Search) ([]byte, error) {
 	return nil, errors.New("multi search is not supported for legacy client")
 }
+
+func (cli *Client) Search(ctx context.Context, search client.Search) ([]byte, error) {
+	return nil, errors.New("search is not supported for legacy client")
+}


### PR DESCRIPTION
### What

Add search method to dp-elasticsearch so application can use the new search client, this should be created for es7.10 (es2 and opensearch can just return an error stating the method has not been implemented).

### How to review

Trello Ticket: https://trello.com/c/NXKbyRVI/951-add-search-method-to-elasticsearch-client-in-dp-elasticsearch

The pr is done against the acceptance criteria of the above trello ticket. 

### Who can review

Anyone except me. 
