### PR TITLE
Add json tag for search header

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ type AddDocumentOptions struct {
 }
 
 type Header struct {
-	Index string
+	Index string `json:"index"`
 }
 
 type Search struct {

--- a/client/elasticsearch/v710/client_test.go
+++ b/client/elasticsearch/v710/client_test.go
@@ -34,9 +34,9 @@ func TestMultiSearch(t *testing.T) {
 		So(err, ShouldEqual, nil)
 		splitQuery := strings.Split(string(body), "\n")
 		So(len(splitQuery), ShouldEqual, expectedMultiLintStringCount)
-		So(splitQuery[0], ShouldEqual, "{\"Index\":\"ons_test\"}")
+		So(splitQuery[0], ShouldEqual, "{\"index\":\"ons_test\"}")
 		So(splitQuery[1], ShouldEqual, "{\"query\" : {\"match\" : { \"message\": \"this is a test\"}}}")
-		So(splitQuery[2], ShouldEqual, "{\"Index\":\"ons_test_2\"}")
+		So(splitQuery[2], ShouldEqual, "{\"index\":\"ons_test_2\"}")
 		So(splitQuery[3], ShouldEqual, "{\"query\" : {\"match_all\" : {}}}")
 	})
 }


### PR DESCRIPTION
### What

This pr fixes the multisearch search document issue as because the index was not json tagged when it tries to search for documents with ```Index``` and not ```index``` in the background it was causing the issue
```elasticsearch key [Index] is not supported in the metadata section```

### How to review

See if this change makes sense. 

### Who can review

Anyone except me. 
