### PR TITLE
Enable setting query parameter for searches

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ type Client interface {
 	GetIndices(ctx context.Context, indexPatterns []string) ([]byte, error)
 	NewBulkIndexer(context.Context) error
 	UpdateAliases(ctx context.Context, alias string, removeIndices, addIndices []string) error
-	MultiSearch(ctx context.Context, searches []Search) ([]byte, error)
+	MultiSearch(ctx context.Context, searches []Search, queryParams *QueryParams) ([]byte, error)
 	Search(ctx context.Context, search Search) ([]byte, error)
 	CountIndices(ctx context.Context, indices []string) ([]byte, error)
 }
@@ -57,4 +57,8 @@ type Header struct {
 type Search struct {
 	Header Header
 	Query  []byte
+}
+
+type QueryParams struct {
+	EnableTotalHitsCounter *bool
 }

--- a/client/elasticsearch/v2/client.go
+++ b/client/elasticsearch/v2/client.go
@@ -239,7 +239,7 @@ func (cli *Client) BulkIndexClose(context.Context) error {
 	return errors.New("bulk index close is currently not supported for legacy client")
 }
 
-func (cli *Client) MultiSearch(ctx context.Context, searches []client.Search) ([]byte, error) {
+func (cli *Client) MultiSearch(ctx context.Context, searches []client.Search, queryParams *client.QueryParams) ([]byte, error) {
 	return nil, errors.New("multi search is not supported for legacy client")
 }
 

--- a/client/elasticsearch/v710/client.go
+++ b/client/elasticsearch/v710/client.go
@@ -254,7 +254,7 @@ func (cli *ESClient) Search(ctx context.Context, search client.Search) ([]byte, 
 
 // Msearch allows to execute several search operations in one request.
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html.
-func (cli *ESClient) MultiSearch(ctx context.Context, searches []client.Search) ([]byte, error) {
+func (cli *ESClient) MultiSearch(ctx context.Context, searches []client.Search, queryParams *client.QueryParams) ([]byte, error) {
 	body, err := convertToMultilineSearches(searches)
 	if err != nil {
 		return nil, err
@@ -262,6 +262,9 @@ func (cli *ESClient) MultiSearch(ctx context.Context, searches []client.Search) 
 
 	req := esapi.MsearchRequest{
 		Body: bytes.NewReader(body),
+	}
+	if queryParams != nil && queryParams.EnableTotalHitsCounter != nil {
+		req.RestTotalHitsAsInt = queryParams.EnableTotalHitsCounter
 	}
 
 	res, err := req.Do(ctx, cli.esClient)

--- a/client/mocks/client.go
+++ b/client/mocks/client.go
@@ -53,7 +53,7 @@ var _ client.Client = &ClientMock{}
 // 			GetIndicesFunc: func(ctx context.Context, indexPatterns []string) ([]byte, error) {
 // 				panic("mock out the GetIndices method")
 // 			},
-// 			MultiSearchFunc: func(ctx context.Context, searches []client.Search) ([]byte, error) {
+// 			MultiSearchFunc: func(ctx context.Context, searches []client.Search, queryParams *client.QueryParams) ([]byte, error) {
 // 				panic("mock out the MultiSearch method")
 // 			},
 // 			NewBulkIndexerFunc: func(contextMoqParam context.Context) error {
@@ -106,7 +106,7 @@ type ClientMock struct {
 	GetIndicesFunc func(ctx context.Context, indexPatterns []string) ([]byte, error)
 
 	// MultiSearchFunc mocks the MultiSearch method.
-	MultiSearchFunc func(ctx context.Context, searches []client.Search) ([]byte, error)
+	MultiSearchFunc func(ctx context.Context, searches []client.Search, queryParams *client.QueryParams) ([]byte, error)
 
 	// NewBulkIndexerFunc mocks the NewBulkIndexer method.
 	NewBulkIndexerFunc func(contextMoqParam context.Context) error
@@ -216,6 +216,8 @@ type ClientMock struct {
 			Ctx context.Context
 			// Searches is the searches argument value.
 			Searches []client.Search
+			// QueryParams is the queryParams argument value.
+			QueryParams *client.QueryParams
 		}
 		// NewBulkIndexer holds details about calls to the NewBulkIndexer method.
 		NewBulkIndexer []struct {
@@ -672,33 +674,37 @@ func (mock *ClientMock) GetIndicesCalls() []struct {
 }
 
 // MultiSearch calls MultiSearchFunc.
-func (mock *ClientMock) MultiSearch(ctx context.Context, searches []client.Search) ([]byte, error) {
+func (mock *ClientMock) MultiSearch(ctx context.Context, searches []client.Search, queryParams *client.QueryParams) ([]byte, error) {
 	if mock.MultiSearchFunc == nil {
 		panic("ClientMock.MultiSearchFunc: method is nil but Client.MultiSearch was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		Searches []client.Search
+		Ctx         context.Context
+		Searches    []client.Search
+		QueryParams *client.QueryParams
 	}{
-		Ctx:      ctx,
-		Searches: searches,
+		Ctx:         ctx,
+		Searches:    searches,
+		QueryParams: queryParams,
 	}
 	mock.lockMultiSearch.Lock()
 	mock.calls.MultiSearch = append(mock.calls.MultiSearch, callInfo)
 	mock.lockMultiSearch.Unlock()
-	return mock.MultiSearchFunc(ctx, searches)
+	return mock.MultiSearchFunc(ctx, searches, queryParams)
 }
 
 // MultiSearchCalls gets all the calls that were made to MultiSearch.
 // Check the length with:
 //     len(mockedClient.MultiSearchCalls())
 func (mock *ClientMock) MultiSearchCalls() []struct {
-	Ctx      context.Context
-	Searches []client.Search
+	Ctx         context.Context
+	Searches    []client.Search
+	QueryParams *client.QueryParams
 } {
 	var calls []struct {
-		Ctx      context.Context
-		Searches []client.Search
+		Ctx         context.Context
+		Searches    []client.Search
+		QueryParams *client.QueryParams
 	}
 	mock.lockMultiSearch.RLock()
 	calls = mock.calls.MultiSearch


### PR DESCRIPTION
### What

Enable setting query parameter for multi searches. Currently this support setting of the ```totalHitCount```. In the future this would be extended to support other parameters. 

### How to review

See if the changes make sense.

### Who can review

Anyone except me. 
