### PR TITLE
Add OnSuccess and OnFailure callbacks for bulk operations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,4 +74,4 @@ type QueryParams struct {
 type SuccessFunc = func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
 
 // FailureFunc is the callback func signature for a successful bulk add operation, as expected by go-elasticsearch
-type FailureFunc = func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)
+type FailureFunc = func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)

--- a/client/client.go
+++ b/client/client.go
@@ -5,14 +5,16 @@ import (
 	"net/http"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
 )
 
 //go:generate moq -out ./mocks/client.go -pkg mocks . Client
 
+// Client holds the methods for ElasticSearch clients
 type Client interface {
 	AddDocument(ctx context.Context, indexName, documentID string, document []byte, opts *AddDocumentOptions) error
 	BulkUpdate(ctx context.Context, indexName, url string, settings []byte) ([]byte, error)
-	BulkIndexAdd(ctx context.Context, action BulkIndexerAction, index, documentID string, document []byte) error
+	BulkIndexAdd(ctx context.Context, action BulkIndexerAction, index, documentID string, document []byte, onSuccess SuccessFunc, onFailure FailureFunc) error
 	BulkIndexClose(context.Context) error
 	Checker(ctx context.Context, state *health.CheckState) error
 	CreateIndex(ctx context.Context, indexName string, indexSettings []byte) error
@@ -67,3 +69,9 @@ type Count struct {
 type QueryParams struct {
 	EnableTotalHitsCounter *bool
 }
+
+// SuccessFunc is the callback func signature for a successful bulk add operation, as expected by go-elasticsearch
+type SuccessFunc = func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
+
+// FailureFunc is the callback func signature for a successful bulk add operation, as expected by go-elasticsearch
+type FailureFunc = func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)

--- a/client/elasticsearch/v2/client.go
+++ b/client/elasticsearch/v2/client.go
@@ -234,7 +234,7 @@ func (cli *Client) NewBulkIndexer(ctx context.Context) error {
 	return errors.New("bulk indexer is not supported for legacy client")
 }
 
-func (cli *Client) BulkIndexAdd(ctx context.Context, action client.BulkIndexerAction, index, documentID string, document []byte) error {
+func (cli *Client) BulkIndexAdd(ctx context.Context, action client.BulkIndexerAction, index, documentID string, document []byte, onSuccess client.SuccessFunc, onFailure client.FailureFunc) error {
 	return errors.New("bulk index add is not supported for legacy client")
 }
 

--- a/client/elasticsearch/v710/bulk_indexer.go
+++ b/client/elasticsearch/v710/bulk_indexer.go
@@ -51,12 +51,22 @@ func newBulkIndexer(es *es710.Client) (*bulkIndexer, error) {
 //
 // It is safe for concurrent use. When it's called from goroutines,
 // they must finish before the call to Close, eg. using sync.WaitGroup.
-func (b *bulkIndexer) Add(ctx context.Context, action client.BulkIndexerAction, index, documentID string, document []byte) error {
+func (b *bulkIndexer) Add(
+	ctx context.Context,
+	action client.BulkIndexerAction,
+	index,
+	documentID string,
+	document []byte,
+	onSuccess client.SuccessFunc,
+	onFailure client.FailureFunc,
+) error {
 	bulkIndexerItem := esutil.BulkIndexerItem{
 		Action:     string(action),
 		Body:       bytes.NewReader(document),
 		DocumentID: documentID,
 		Index:      index,
+		OnSuccess:  onSuccess,
+		OnFailure:  onFailure,
 	}
 
 	return b.bi.Add(ctx, bulkIndexerItem)

--- a/client/elasticsearch/v710/bulk_indexer_test.go
+++ b/client/elasticsearch/v710/bulk_indexer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	es710 "github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -49,8 +50,20 @@ func TestBulkIndexerMethods(t *testing.T) {
 			t.Errorf("failed to setup bulk indexer for test")
 		}
 
-		Convey("When calling Add method", func() {
-			err := bulkIndexer.Add(testCtx, Create, indexName, "123", []byte{})
+		Convey("When calling Add method with nil callbacks", func() {
+			err := bulkIndexer.Add(testCtx, Create, indexName, "123", []byte{}, nil, nil)
+
+			Convey("Then item is added to the bulk indexer without errors", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When calling Add method with callbacks", func() {
+			onSuccess := func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem) {
+			}
+			onFailure := func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error) {
+			}
+			err := bulkIndexer.Add(testCtx, Create, indexName, "123", []byte{}, onSuccess, onFailure)
 
 			Convey("Then item is added to the bulk indexer without errors", func() {
 				So(err, ShouldBeNil)

--- a/client/elasticsearch/v710/bulk_indexer_test.go
+++ b/client/elasticsearch/v710/bulk_indexer_test.go
@@ -61,7 +61,7 @@ func TestBulkIndexerMethods(t *testing.T) {
 		Convey("When calling Add method with callbacks", func() {
 			onSuccess := func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem) {
 			}
-			onFailure := func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error) {
+			onFailure := func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error) {
 			}
 			err := bulkIndexer.Add(testCtx, Create, indexName, "123", []byte{}, onSuccess, onFailure)
 

--- a/client/elasticsearch/v710/client.go
+++ b/client/elasticsearch/v710/client.go
@@ -413,7 +413,15 @@ func (cli *ESClient) NewBulkIndexer(ctx context.Context) error {
 //
 // It is safe for concurrent use. When it's called from goroutines,
 // they must finish before the call to Close, eg. using sync.WaitGroup.
-func (cli *ESClient) BulkIndexAdd(ctx context.Context, action client.BulkIndexerAction, index, documentID string, document []byte) error {
+func (cli *ESClient) BulkIndexAdd(
+	ctx context.Context,
+	action client.BulkIndexerAction,
+	index,
+	documentID string,
+	document []byte,
+	onSuccess client.SuccessFunc,
+	onFailure client.FailureFunc,
+) error {
 	if cli.bulkIndexer == nil {
 		return esError.StatusError{
 			Err:  errors.New(bulkIndexerClientShouldNotBeNilErrMsg),
@@ -421,7 +429,7 @@ func (cli *ESClient) BulkIndexAdd(ctx context.Context, action client.BulkIndexer
 		}
 	}
 
-	return cli.bulkIndexer.Add(ctx, action, index, documentID, document)
+	return cli.bulkIndexer.Add(ctx, action, index, documentID, document, onSuccess, onFailure)
 }
 
 // Close waits until all added items are flushed and closes the indexer.

--- a/client/mocks/client.go
+++ b/client/mocks/client.go
@@ -24,7 +24,7 @@ var _ client.Client = &ClientMock{}
 //			AddDocumentFunc: func(ctx context.Context, indexName string, documentID string, document []byte, opts *client.AddDocumentOptions) error {
 //				panic("mock out the AddDocument method")
 //			},
-//			BulkIndexAddFunc: func(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)) error {
+//			BulkIndexAddFunc: func(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)) error {
 //				panic("mock out the BulkIndexAdd method")
 //			},
 //			BulkIndexCloseFunc: func(contextMoqParam context.Context) error {
@@ -80,7 +80,7 @@ type ClientMock struct {
 	AddDocumentFunc func(ctx context.Context, indexName string, documentID string, document []byte, opts *client.AddDocumentOptions) error
 
 	// BulkIndexAddFunc mocks the BulkIndexAdd method.
-	BulkIndexAddFunc func(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)) error
+	BulkIndexAddFunc func(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)) error
 
 	// BulkIndexCloseFunc mocks the BulkIndexClose method.
 	BulkIndexCloseFunc func(contextMoqParam context.Context) error
@@ -154,7 +154,7 @@ type ClientMock struct {
 			// OnSuccess is the onSuccess argument value.
 			OnSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
 			// OnFailure is the onFailure argument value.
-			OnFailure func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)
+			OnFailure func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)
 		}
 		// BulkIndexClose holds details about calls to the BulkIndexClose method.
 		BulkIndexClose []struct {
@@ -328,7 +328,7 @@ func (mock *ClientMock) AddDocumentCalls() []struct {
 }
 
 // BulkIndexAdd calls BulkIndexAddFunc.
-func (mock *ClientMock) BulkIndexAdd(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)) error {
+func (mock *ClientMock) BulkIndexAdd(ctx context.Context, action client.BulkIndexerAction, index string, documentID string, document []byte, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)) error {
 	if mock.BulkIndexAddFunc == nil {
 		panic("ClientMock.BulkIndexAddFunc: method is nil but Client.BulkIndexAdd was just called")
 	}
@@ -339,7 +339,7 @@ func (mock *ClientMock) BulkIndexAdd(ctx context.Context, action client.BulkInde
 		DocumentID string
 		Document   []byte
 		OnSuccess  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
-		OnFailure  func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)
+		OnFailure  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)
 	}{
 		Ctx:        ctx,
 		Action:     action,
@@ -366,7 +366,7 @@ func (mock *ClientMock) BulkIndexAddCalls() []struct {
 	DocumentID string
 	Document   []byte
 	OnSuccess  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
-	OnFailure  func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)
+	OnFailure  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)
 } {
 	var calls []struct {
 		Ctx        context.Context
@@ -375,7 +375,7 @@ func (mock *ClientMock) BulkIndexAddCalls() []struct {
 		DocumentID string
 		Document   []byte
 		OnSuccess  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem)
-		OnFailure  func(ctx context.Context, bii esutil.BulkIndexerItem, biri esutil.BulkIndexerResponseItem, err error)
+		OnFailure  func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error)
 	}
 	mock.lockBulkIndexAdd.RLock()
 	calls = mock.calls.BulkIndexAdd


### PR DESCRIPTION
### What

This issue was identified while trying to debug issues for [this spike](https://trello.com/c/30uwopFT/1233-spike-investigate-what-the-data-model-should-be-for-storing-dimensions-and-population-types-in-es)

- Modify BulkIndexAdd to accept onSuccess and onFailure callbacks (called by `go-elasticsearch` when the operation fails or succeeds, asynchronously)
- Modify necessary interfaces and methods (v2 does not implement bulk operations, so nothing changes for it)
- Add test case

I know this modifies the library interface, but version 3 is still alpha.

### How to review

- Make sure code changes make sense

### Who can review

Anyone